### PR TITLE
Only show payment and card information in the admin

### DIFF
--- a/Block/Info.php
+++ b/Block/Info.php
@@ -55,7 +55,7 @@ class Info extends ConfigurableInfo
     {
         $info = parent::getSpecificInformation();
 
-        if ($this->getIsSecureMode()) {
+        if (!$this->getIsSecureMode()) {
             /** @var Payment $payment */
             $payment = $this->getInfo();
 

--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -3,7 +3,7 @@
     <type name="Stripeofficial\CreditCards\Block\Info">
         <arguments>
             <argument name="data" xsi:type="array">
-                <item xsi:type="string" name="is_secure_mode">1</item>
+                <item xsi:type="string" name="is_secure_mode">0</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
Previously payment and card information was also shown in the frontend and customer emails. This changeset makes sure this information is not shown when in secure mode, and makes sure that for the admin secure mode is set to 0.

This resolves issue #3.