### PR TITLE
Fix for properly handling multi-store when refunding a payment

### DIFF
--- a/Gateway/Http/Client/ClientMock.php
+++ b/Gateway/Http/Client/ClientMock.php
@@ -8,6 +8,7 @@ use Magento\Framework\UrlInterface;
 use Magento\Payment\Gateway\Http\ClientInterface;
 use Magento\Payment\Gateway\Http\TransferInterface;
 use Stripeofficial\Core\Helper\Data;
+use Stripeofficial\Core\Model\DataProvider;
 use Stripeofficial\Core\Model\Logger;
 use Stripeofficial\Core\Api\PaymentInterface;
 use Stripeofficial\CreditCards\Gateway\Config\Config;
@@ -46,6 +47,10 @@ class ClientMock implements ClientInterface
      * @var Data
      */
     protected $data;
+    /**
+     * @var DataProvider
+     */
+    private $dataProvider;
 
     /**
      * ClientMock constructor.
@@ -60,13 +65,15 @@ class ClientMock implements ClientInterface
         Config $config,
         CustomerRepositoryInterface $customerRepository,
         UrlInterface $urlBuilder,
-        Data $data
+        Data $data,
+        DataProvider $dataProvider
     ) {
         $this->creditCardPayment = $creditCardPayment;
         $this->config = $config;
         $this->customerRepository = $customerRepository;
         $this->urlBuilder = $urlBuilder;
         $this->data = $data;
+        $this->dataProvider = $dataProvider;
     }
 
     /**
@@ -79,6 +86,10 @@ class ClientMock implements ClientInterface
     public function placeRequest(TransferInterface $transferObject)
     {
         $body = $transferObject->getBody();
+
+        if (isset($body['store_id'])) {
+            $this->dataProvider->setCurrentStoreId($body['store_id']);
+        }
 
         if (isset($body['CURRENCY_CODE']) && $body['CURRENCY_CODE'] == 'jpy') {
             $body['AMOUNT'] = $body['AMOUNT'] / 100;

--- a/Gateway/Request/RefundRequest.php
+++ b/Gateway/Request/RefundRequest.php
@@ -43,6 +43,7 @@ class RefundRequest implements BuilderInterface
             'TXN_ID' => $transactionId,
             'CURRENCY_CODE' => isset($paymentAdditionalInformation['currencyCode']) ? $paymentAdditionalInformation['currencyCode'] : $order->getCurrencyCode(),
             'REFUND_AMOUNT' => $amount,
+            'store_id' => $order->getStoreId(),
         ];
     }
 }


### PR DESCRIPTION
In case of multi store configuration with each store using different Stripe account, there was an issue for refunding payment through the back office. The module was always taking default Stripe API key instead of the one of the store of order to be refunded.

This PR fix this issue.